### PR TITLE
Fixes aarch64 build by including stddef.h

### DIFF
--- a/sinc_resampler.h
+++ b/sinc_resampler.h
@@ -19,6 +19,8 @@
  /* Modified by Janne Hyvärinen */
  /* Modified some more by Peter Pawlowski */
 
+#include <stddef.h> 
+
 #pragma once
 
 #define __forceinline


### PR DESCRIPTION
Currently the build of libretro in deadbeef on aarch64 fails with the following

        libtool: compile:  aarch64-unknown-linux-gnu-clang++ -DHAVE_CONFIG_H -I. -I../.. -O2 -pipe -fomit-frame-pointer -D_GNU_SOURCE -D__EXTENSIONS__ -DLIBDIR=\"/usr/lib64\" -DPREFIX=\"/usr\" -DDOCDIR=\"/usr/share/doc/deadbeef-1.9.5\" -DDDB_WARN_DEPRECATED=1 -msse3 -std=c++11 -O2 -pipe -fomit-frame-pointer -D_GNU_SOURCE -D__EXTENSIONS__ -DLIBDIR=\"/usr/lib64\" -DPREFIX=\"/usr\" -DDOCDIR=\"/usr/share/doc/deadbeef-1.9.5\" -DDDB_WARN_DEPRECATED=1 -c libretro.cpp  -fPIC -DPIC -o .libs/ddb_dsp_libretro_la-libretro.o
        clang-15: warning: argument unused during compilation: '-msse3' [-Wunused-command-line-argument]
        In file included from libretro.cpp:21:
        ./sinc_resampler.h:54:5: error: unknown type name 'size_t'
            size_t input_frames;
            ^
        ./sinc_resampler.h:55:5: error: unknown type name 'size_t'
            size_t output_frames;
            ^
        2 errors generated.

Adding the stddef.h fixes it.